### PR TITLE
wrap repo-update-cadist execution in simple flock (SOFTWARE-3234)

### DIFF
--- a/repo-update-cadist.cron
+++ b/repo-update-cadist.cron
@@ -1,4 +1,4 @@
 # Update cadist under /usr/local/repo/cadist
 # Updates and errors go to /var/log/repo-update-cadist.{stdout,stderr}
-*/10 * * * * root /usr/bin/repo-update-cadist
+*/10 * * * * root flock -n /var/lock/repo-update-cadist /usr/bin/repo-update-cadist
 


### PR DESCRIPTION
This should prevent multiple instances from running concurrently.

We would also like to make a systemd timer for EL7, but the current change is just for the cron file.