### PR TITLE
Drop temporary link fix (SOFTWARE-3874)

### DIFF
--- a/repo-update-cadist
+++ b/repo-update-cadist
@@ -217,9 +217,6 @@ for TYPES in NEW IGTFNEW; do
     fi
 done
 
-# temporary fix for broken links in INDEX.html (SOFTWARE-4091)
-# (needs to be fixed in mk-index.pl in the osg-certificates package)
-
 IGTFNEW_BUNDLE=${VER_IGTFNEW}/osg-certificates-${VER_IGTFNEW}.tar.gz
 NEW_BUNDLE=${VER_NEW}/osg-certificates-${VER_NEW}.tar.gz
 
@@ -227,7 +224,6 @@ sed -i -e "/Latest IGTF CA bundle/s|href='[^']*'|href='$IGTFNEW_BUNDLE'|" \
        -e "/Latest OSG CA bundle/s|href='[^']*'|href='$NEW_BUNDLE'|"      \
     ${TMPROOT}/cadist/${VER_IGTFNEW}/INDEX.html                           \
     ${TMPROOT}/cadist/${VER_NEW}/INDEX.html
-
 
 chmod -R ug+rwX "${TMPROOT}/cadist/"
 chmod -R o+rX "${TMPROOT}/cadist/"

--- a/repo-update-cadist
+++ b/repo-update-cadist
@@ -135,7 +135,6 @@ for TYPES in NEW IGTFNEW; do
     ## Save the tarball
     CADIR="${TMPROOT}/cadist/${VERSION_CA}${SUFFIX}"
     CATARBALL="${CADIR}/$TARBALL"
-    eval VER_${SUFFIX}='${VERSION_CA}${SUFFIX}'
 
     mkdir -p "${CADIR}"
     mv -f "$TARBALL" "$CATARBALL"
@@ -216,14 +215,6 @@ for TYPES in NEW IGTFNEW; do
         echo "$(date) updated to new version ${VERSION_CA}${SUFFIX}" >>$UPDATELOG
     fi
 done
-
-IGTFNEW_BUNDLE=${VER_IGTFNEW}/osg-certificates-${VER_IGTFNEW}.tar.gz
-NEW_BUNDLE=${VER_NEW}/osg-certificates-${VER_NEW}.tar.gz
-
-sed -i -e "/Latest IGTF CA bundle/s|href='[^']*'|href='$IGTFNEW_BUNDLE'|" \
-       -e "/Latest OSG CA bundle/s|href='[^']*'|href='$NEW_BUNDLE'|"      \
-    ${TMPROOT}/cadist/${VER_IGTFNEW}/INDEX.html                           \
-    ${TMPROOT}/cadist/${VER_NEW}/INDEX.html
 
 chmod -R ug+rwX "${TMPROOT}/cadist/"
 chmod -R o+rX "${TMPROOT}/cadist/"

--- a/rpm/repo-update-cadist.spec
+++ b/rpm/repo-update-cadist.spec
@@ -1,6 +1,6 @@
 Name:      repo-update-cadist
 Summary:   repo-update-cadist
-Version:   1.1.1
+Version:   1.1.2
 Release:   1%{?dist}
 License:   Apache 2.0
 Group:     Grid
@@ -40,6 +40,9 @@ install -pm 644 %{name}.cron  $RPM_BUILD_ROOT%{_sysconfdir}/cron.d/
 %endif
 
 %changelog
+* Thu Jul 30 2020 Carl Edquist <edquist@cs.wisc.edu> - 1.1.2-1
+- Stop fixing broken CA bundle tarball links in INDEX.html (SOFTWARE-3874)
+
 * Thu May 07 2020 Carl Edquist <edquist@cs.wisc.edu> - 1.1.1-1
 - Fix broken CA bundle tarball links in INDEX.html files (SOFTWARE-4091)
 


### PR DESCRIPTION
Can be released after https://github.com/opensciencegrid/osg-certificates/pull/1

See also SOFTWARE-4091.
