### PR TITLE
fix path to OSG tarball in IGTF INDEX.html (SOFTWARE-4394)

### DIFF
--- a/repo-update-cadist
+++ b/repo-update-cadist
@@ -216,6 +216,11 @@ for TYPES in NEW IGTFNEW; do
     fi
 done
 
+# fix path to OSG tarball in IGTF INDEX.html (SOFTWARE-4394)
+latest_osg_line=$(grep "Latest OSG CA bundle" ${TMPROOT}/cadist/index-new.html)
+igtf_html_path=$(readlink -f ${TMPROOT}/cadist/index-igtf-new.html)
+sed -i "/Latest OSG CA bundle/s|.*|$latest_osg_line|" "$igtf_html_path"
+
 chmod -R ug+rwX "${TMPROOT}/cadist/"
 chmod -R o+rX "${TMPROOT}/cadist/"
 chown root:root "${TMPROOT}/cadist/"


### PR DESCRIPTION
The osg-ca-certs and igtf-ca-certs builds each have an associated igtf
and osg version.  Each of these builds also contains an INDEX.html,
which has links to the igtf and osg tarballs with their respective
versions.

The repo-update-cadist script makes the main cadist/index.html refer to
te igtf version.  The implication is that when a new osg-ca-certs
version is released without also doing an igtf release, the
cadist/index.html page will refer to the osg tarball according to the
osg version in the igtf-ca-certs build, which is then older than the osg
version in the new osg-ca-certs build, meaning the osg tarball link will
be wrong.

Two possible solutions are:

1. always release osg-ca-certs and igtf-ca-certs builds together
(perhaps just bumping the release for igtf-ca-certs if the igtf version
is not increased), or

2. borrow the osg tarball link from the osg-ca-certs INDEX.html and
patch it into the main index.html to replace the one from igtf-ca-certs.

Well, maybe 2 is a bit of a hack but it makes for one less package to
release sometimes, i guess.

...

Fixed the issue for me on [repo-itb](http://repo-itb.opensciencegrid.org/cadist/).